### PR TITLE
net, stuntime: Align stuntime STP with global threshold policy

### DIFF
--- a/stps/sig-network/stuntime_measurement.md
+++ b/stps/sig-network/stuntime_measurement.md
@@ -34,7 +34,7 @@ The feature defines and measures VM stuntime during live migration and establish
 | **Understand Value**                   | [x]  | Network connectivity downtime measurements and their resulting values provide users a set of expectations for VM downtime during live migration and allow comparison of OCP-V with other virtualization solutions. |          |
 | **Customer Use Cases**                 | [x]  | Users performing live migrations need reference values to understand expected network connectivity downtime. Users evaluating OCP-V also need stuntime data to compare with other virtualization solutions. |          |
 | **Testability**                        | [x]  | Testable by measuring the time period in which network traffic is lost. |          |
-| **Acceptance Criteria**                | [x]  | Measured values are published as reference data per release; they are not a formal SLA commitment across all environments and conditions. A per-scenario threshold exists for regression detection. | These values are best-effort; actual stuntime may vary across different environments. |
+| **Acceptance Criteria**                | [x]  | Measured values are published as reference data per release; they are not a formal SLA commitment across all environments and conditions. A single global threshold exists for regression detection (see Section II.1). | These values are best-effort; actual stuntime may vary across different environments. |
 | **Non-Functional Requirements (NFRs)** | [x]  | Measured stuntime will be documented in a KCS or a Red Hat blog post. |          |
 
 #### **2. Known Limitations**
@@ -59,10 +59,13 @@ No known technical limitations. All scope exclusions are documented in the Out-o
 
 Tests measure network connectivity stuntime during live migration. Connectivity is measured on secondary networks (Linux bridge and OVN localnet). The test scenarios reflect different migration paths and ARP/CNI behavior during migration. Since stuntime can differ depending on who initiates traffic, both traffic initiation directions will be measured. All scenarios are measured for both IPv4 and IPv6. Measurements are taken on an idle cluster with a minimal VM setup; results reflect expected stuntime under those conditions.
 
+**Threshold policy** -
+We commit initially to a single global threshold that fits all stuntime measurement scenarios. In the future, if lower granularity is needed, we can move to more specific thresholds per CNI or another grouping.
+
 **Testing Goals**
 
 - **[P0]** VM with secondary network connected to a Linux bridge:
-  - Verify stuntime stays within the per-scenario threshold for the following variants:
+  - Verify stuntime stays within the global threshold for the following variants:
     - IP Family: IPv4, IPv6
     - Connectivity initiator: Client (initiator), Server (listener).
     - Migration paths (relative to the node hosting the connectivity peer):
@@ -70,7 +73,7 @@ Tests measure network connectivity stuntime during live migration. Connectivity 
       - Initially running on different nodes, reaching the same node.
       - Always running on different nodes.
 - **[P0]** VM with secondary network connected to OVN localnet:
-  - Verify stuntime stays within the per-scenario threshold for the following variants:
+  - Verify stuntime stays within the global threshold for the following variants:
     - IP Family: IPv4, IPv6
     - Connectivity initiator: Client (initiator), Server (listener).
     - Migration paths (relative to the node hosting the connectivity peer):
@@ -84,7 +87,7 @@ Tests measure network connectivity stuntime during live migration. Connectivity 
 |:--------------------------------------------------|:----------------------------------------------------------------------------------------------|:-------------------|
 | Default pod network / masquerade                  | To save capacity, stuntime coverage is limited to the vast majority of client scenarios - secondary networks. | [x] phoracek@redhat.com (03/2026) |
 | Other secondary CNIs (e.g. SR-IOV, other plugins) | Stuntime coverage is limited to the vast majority of client scenarios - Linux bridge and OVN localnet. | [x] phoracek@redhat.com (03/2026) |
-| Worst-case SLA guarantee | The tests assert a per-scenario threshold for regression detection, but this threshold is not a public SLA commitment. These values are best-effort; Different HW, load, and network conditions may influence stuntime. | [x] phoracek@redhat.com (03/2026) |
+| Worst-case SLA guarantee | The tests assert a global threshold for regression detection, but this threshold is not a public SLA commitment. These values are best-effort; Different HW, load, and network conditions may influence stuntime. | [x] phoracek@redhat.com (03/2026) |
 | General performance testing | Testing is scoped to a stable environment with no performance or scale focus. High-density stress testing and measuring stuntime under heavy cluster load are out of scope. | [x] phoracek@redhat.com (03/2026) |
 | Upgrade | These tests will not be added to the upgrade CI lane. Baseline is measured on an idle cluster; the upgrade lane runs with heavier load and is out of scope for the current epic. | [x] phoracek@redhat.com (03/2026) |
 | localnet over br-ex | To save team capacity, coverage focuses on the recommended configuration: dedicated NICs for VM network. | [x] phoracek@redhat.com (03/2026) |
@@ -101,8 +104,8 @@ Tests measure network connectivity stuntime during live migration. Connectivity 
 | Security Testing               | Verifies security requirements, RBAC, authentication, authorization, and vulnerability scanning                                                              | N/A                     | Not applicable to stuntime measurement.                                                   |
 | Usability Testing              | Validates user experience, UI/UX consistency, and accessibility requirements. Does the feature require UI? If so, ensure the UI aligns with the requirements | N                       | No UI planned for this feature.                                                          |
 | Compatibility Testing          | Ensures feature works across supported platforms, versions, and configurations                                                                               | N                       | No new feature or configuration introduced; stuntime measurement runs on a fixed BM environment and does not require cross-configuration validation.                                                                                           |
-| Regression Testing             | Verifies that new changes do not break existing functionality                                                                                                | Y                       | Regression is detected via the per-scenario threshold shared between all versions.                                                               |
-| Upgrade Testing                | Validates upgrade paths from previous versions, data migration, and configuration preservation                                                               | N                       | Not added to the upgrade CI lane. Regression detection across versions is handled by the per-scenario threshold shared between all versions.                                                               |
+| Regression Testing             | Verifies that new changes do not break existing functionality                                                                                                | Y                       | Regression is detected via the global threshold shared between all versions.                                                               |
+| Upgrade Testing                | Validates upgrade paths from previous versions, data migration, and configuration preservation                                                               | N                       | Not added to the upgrade CI lane. Regression detection across versions is handled by the global threshold shared between all versions.                                                               |
 | Backward Compatibility Testing | Ensures feature maintains compatibility with previous API versions and configurations                                                                        | N/A                    | The stuntime is a performance measurement addition, not a product feature. No APIs or configurations are introduced that users depend on.                                                                           |
 | Dependencies                   | Dependent on deliverables from other components/products? Identify what is tested by which team.                                                             | N                       | Uses existing migration and secondary network topologies.                                     |
 | Cross Integrations             | Does the feature affect other features/require testing by other components? Identify what is tested by which team.                                           | N                       | Tests are self-contained and do not affect other features.                                                                                           |
@@ -146,7 +149,7 @@ The following conditions must be met before testing can begin:
 | Test Coverage        | Regressions in default pod network or other CNIs (e.g. SR-IOV) may go undetected.             | Coverage limited to bridge and localnet by design. Explicit out-of-scope notes. Can be extended later if requirements change.                                                                      | [x]    |
 | Test Environment     | Stuntime values may vary across environments (different labs, HW, network config); even on an idle BM, results from one setup may not reflect another. | Baseline will be derived from repeated runs on a stable BM setup; the threshold defined will be based on a multiplier to absorb variance. | [x]    |
 | Untestable Aspects   | Stuntime under performance and scale conditions (high cluster load, concurrent migrations) is unknown. | Results reflect idle cluster with minimal VM setup only; explicitly out of scope.                                                                                                                  | [x]    |
-| Upgrade              | A regression introduced during an OCP-V upgrade may go undetected since tests do not run in the upgrade CI lane. | The per-scenario threshold is shared between all versions; if stuntime regresses post-upgrade, it will be caught when the tests run on the new version.                                            | [x]    |
+| Upgrade              | A regression introduced during an OCP-V upgrade may go undetected since tests do not run in the upgrade CI lane. | The global threshold is shared between all versions; if stuntime regresses post-upgrade, it will be caught when the tests run on the new version.                                            | [x]    |
 | Resource Constraints | N/A                                                                                            | -                                                                                                                                                                                                  | [x]    |
 | Dependencies         | N/A                                                                                            | -                                                                                                                                                                                                  | [x]    |
 
@@ -158,8 +161,8 @@ Scenario Variants: See **Testing Goals** (Section II.1) for details.
 
 | Requirement ID | Requirement Summary | Test Scenario(s) | Tier | Priority |
 |:---------------|:--------------------|:-----------------|:-----|:---------|
-| CNV-72773 | Measure VM stuntime over Linux bridge | Verify stuntime during live migration over Linux bridge within the per-scenario threshold | Tier 2 | P0 |
-| CNV-72773 | Measure VM stuntime over OVN localnet | Verify stuntime during live migration over OVN localnet within the per-scenario threshold | Tier 2 | P0 |
+| CNV-72773 | Measure VM stuntime over Linux bridge | Verify stuntime during live migration over Linux bridge within the global threshold | Tier 2 | P0 |
+| CNV-72773 | Measure VM stuntime over OVN localnet | Verify stuntime during live migration over OVN localnet within the global threshold | Tier 2 | P0 |
 
 ---
 


### PR DESCRIPTION
### What this PR does
The epic calls for a single global stuntime threshold; the STP should state that commitment clearly. Add a short note that finer thresholds (e.g. per grouping) remain an option if we are asked to go there later.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated stuntime regression detection to use a single global threshold across all measurement scenarios, replacing per-scenario thresholds. Acceptance criteria, a new threshold policy, testing goals for Linux bridge and OVN localnet variants, worst-case SLA wording, regression/upgrade testing descriptions, and scenario traceability verification were all revised to reference the global threshold.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->