### PR TITLE
net: Add devs as owners

### DIFF
--- a/stps/sig-network/OWNERS
+++ b/stps/sig-network/OWNERS
@@ -7,3 +7,6 @@ reviewers:
   - EdDev
   - servolkov
   - azhivovk
+  - orelmisan
+  - nirdothan
+  - frenzyfriday


### PR DESCRIPTION
Net developers are added to the owners to review and lgtm network STPs