### PR TITLE
feat: add child STP directory structure for multi-SIG features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -245,6 +245,48 @@ When an STP spans multiple SIGs:
 - Each SIG's regression responsibility must be explicitly documented
 - Cross-SIG test scenarios (e.g., cross-architecture VM connectivity) must have a clear owner
 
+### Directory Structure
+
+Multi-SIG features use a **feature directory** under the owning SIG:
+
+```text
+stps/<owning-sig>/<feature-name>/
+├── stp.md              ← parent STP (owned by the feature's primary SIG)
+├── <sig-name>.md       ← child STP per participating SIG
+└── ...
+```
+
+Example — multi-arch feature owned by sig-iuo with 4 participating SIGs:
+
+```text
+stps/sig-iuo/multiarch/
+├── stp.md
+├── network.md
+├── storage.md
+├── virt.md
+└── infra.md
+```
+
+**Rules:**
+
+- The parent STP (`stp.md`) defines the overall scope, requirements, and acceptance criteria
+- Each child STP covers only the participating SIG's test scope — goals, scenarios, and risks
+  specific to that SIG
+- Child STPs reference the parent for shared context (Feature Overview, requirements, acceptance
+  criteria) — they do NOT repeat it
+- The feature directory may include an `OWNERS` file listing reviewers from all participating SIGs
+- Single-SIG features do NOT use a feature directory — place the STP directly under `stps/<sig>/`
+
+### Child STP Review Checklist
+
+- [ ] Parent STP lists all child STPs in the feature directory with links
+- [ ] Child STP does NOT duplicate Feature Overview, requirements, or acceptance criteria from parent
+- [ ] Child STP defines only the participating SIG's test scope, scenarios, and risks
+- [ ] When a child STP is added to a feature directory that already has a parent STP,
+  verify the parent is updated to include the new child
+- [ ] When a parent STP is added to a feature directory that already contains child STPs,
+  verify the parent lists all existing children
+
 ---
 
 ## Content Quality Rules

--- a/docs/stp-guide.md
+++ b/docs/stp-guide.md
@@ -27,6 +27,25 @@ The STP is a **mandatory deliverable** for formal QE sign-off and feature accept
 
 The STP template includes the following main sections:
 
+### Multi-SIG Features and Child STPs
+
+When a feature spans multiple SIGs, use a **feature directory** under the owning SIG.
+The parent STP defines the overall scope, and each participating SIG contributes a child STP
+that covers their specific test scope.
+
+```text
+stps/<owning-sig>/<feature-name>/
+├── stp.md              ← parent STP
+├── <sig-name>.md       ← child STP per participating SIG
+└── ...
+```
+
+**Parent STP** — defines Feature Overview, requirements, acceptance criteria, and overall coordination.
+**Child STPs** — define SIG-specific testing goals, scenarios, strategy, and risks. They reference
+the parent for shared context and do NOT duplicate it.
+
+Single-SIG features place the STP directly under `stps/<sig>/` without a feature directory.
+
 ### I. Motivation and Requirements Review
 
 **Purpose:** Ensure QE understands the feature value and testability before planning begins.

--- a/stps/stp-template/stp.md
+++ b/stps/stp-template/stp.md
@@ -11,6 +11,14 @@
 - **QE Owner(s):** [Name(s)]
 - **Owning SIG:** [sig-xyz]
 - **Participating SIGs:** [List of participating SIGs]
+- **Child STPs:** [List child STPs with links, or remove this field for single-SIG features]
+  <!-- For parent STPs in multi-SIG features only: list all child STPs in the feature directory.
+  Remove this field for single-SIG features and child STPs.
+
+  Example:
+  - [sig-network](./network.md)
+  - [sig-storage](./storage.md)
+  - [sig-virt](./virt.md) -->
 
 **Document Conventions (if applicable):** [Define acronyms or terms specific to this document]
 


### PR DESCRIPTION
### What this PR does

Defines the directory pattern for multi-SIG features where multiple SIGs contribute child STPs alongside a parent STP.

### Why

Multi-SIG features (e.g., multi-arch, RHCOS9/10 heterogeneous clusters) need a consistent structure. Without it, child STPs are scattered across SIG directories with no clear parent-child relationship.

### Directory pattern

```text
stps/<owning-sig>/<feature-name>/
├── stp.md              ← parent STP
├── <sig-name>.md       ← child STP per participating SIG
└── ...
```

### Changes

**`AGENTS.md`:**
- Directory structure diagram with example
- Rules for parent vs child STP content separation
- Child STP review checklist ensuring parent-child consistency in both directions

**`docs/stp-guide.md`:**
- New "Multi-SIG Features and Child STPs" section

**`stps/stp-template/stp.md`:**
- `Child STPs` metadata field for parent STPs to list all children with links

### Key rules

- Parent STP owns the overall scope, requirements, and acceptance criteria
- Child STPs extend (not duplicate) the parent with SIG-specific goals, scenarios, and risks
- When a child is added → parent must be updated to list it
- When a parent is added → it must list all existing children in the directory

Assisted-by: Claude <noreply@anthropic.com>