### PR TITLE
agents: clarify risk section rules for no-risk entries and optional Other category

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -202,13 +202,15 @@ Assisted-by: Claude <noreply@anthropic.com>
 - [ ] ALL 7 risk categories are addressed (even if N/A with justification):
   Timeline/Schedule, Test Coverage, Test Environment, Untestable Aspects,
   Resource Constraints, Dependencies, Other
-- [ ] Each risk has: Risk description, Mitigation strategy, Sign-off
-- [ ] N/A risks have brief justification (not just "N/A")
+- [ ] When a risk exists: full entry required — Risk description, Mitigation strategy, Sign-off
+- [ ] When no risk exists: only Mitigation is required, with a brief justification of why there
+  is no risk (not just "N/A"); no Sign-off or other category-specific fields are needed
 - [ ] Mitigations are specific and actionable (not "we will address this")
 
 **Common rejection reasons:**
 - All risks marked N/A (unrealistic — every feature has some risk)
-- Missing sign-off fields on risk entries
+- Missing sign-off on risk entries where a real risk is described
+- Mitigation says "N/A" without explaining why no mitigation is needed
 - Vague mitigations without specific actions
 - Missing risk categories entirely
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -203,9 +203,16 @@ Assisted-by: Claude <noreply@anthropic.com>
   Timeline/Schedule, Test Coverage, Test Environment, Untestable Aspects,
   Resource Constraints, Dependencies
 - [ ] "Other" category is included only if risks exist that don't fit the 6 standard categories above
-- [ ] When a risk exists: full entry required — Risk description, Mitigation strategy, Sign-off
-- [ ] When no risk exists: only Mitigation is required, with a brief justification of why there
-  is no risk (not just "N/A"); no Sign-off or other category-specific fields are needed
+- [ ] When a risk exists: full entry required — Risk description, Mitigation strategy, Sign-off,
+  and the category-specific supplemental field:
+  *Estimated impact on schedule* (Timeline/Schedule),
+  *Areas with reduced coverage* (Test Coverage),
+  *Missing or unavailable environments* (Test Environment),
+  *Missing resources or infrastructure* (Resource Constraints),
+  *Third-party services or blockers* (Dependencies),
+  *Reason untestable and mitigation approach* (Untestable Aspects)
+- [ ] When no risk exists: only a short justification in the Mitigation field is needed
+  (not just "N/A"); no Sign-off or category-specific supplemental fields are required
 - [ ] Mitigations are specific and actionable (not "we will address this")
 
 **Common rejection reasons:**

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -199,9 +199,10 @@ Assisted-by: Claude <noreply@anthropic.com>
 
 ### II.5 — Risks
 
-- [ ] ALL 7 risk categories are addressed (even if N/A with justification):
+- [ ] ALL 6 standard risk categories are addressed (even if no risk, include Mitigation with brief justification):
   Timeline/Schedule, Test Coverage, Test Environment, Untestable Aspects,
-  Resource Constraints, Dependencies, Other
+  Resource Constraints, Dependencies
+- [ ] "Other" category is included only if risks exist that don't fit the 6 standard categories above
 - [ ] When a risk exists: full entry required — Risk description, Mitigation strategy, Sign-off
 - [ ] When no risk exists: only Mitigation is required, with a brief justification of why there
   is no risk (not just "N/A"); no Sign-off or other category-specific fields are needed


### PR DESCRIPTION
## Summary

- When no risk exists in a category, only the **Mitigation** field is required with a brief justification — no Sign-off or category-specific fields needed. Sign-off is only required when an actual risk is described.
- The **Other** risk category is now optional — only include it when risks exist that don't fit the 6 standard categories. Requiring it when there is nothing to add is unnecessary noise.

## Test plan

- [ ] Review `AGENTS.md` II.5 section to confirm the updated rules are clear and unambiguous
- [ ] Verify the rules are correctly applied when reviewing the next STP PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated risk assessment checklist to expect 6 standard risk categories (reduced from 7).
  * Refined requirements for risk documentation: actual risks now require full field completion, while no-risk scenarios only need brief justification.
  * Updated rejection criteria for incomplete submissions, including clearer sign-off conditions and N/A validation rules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->