### PR TITLE
Dual-stream network STP refactor

### DIFF
--- a/stps/sig-virt/dual-stream-cluster-rhcos9-rhcos10/network.md
+++ b/stps/sig-virt/dual-stream-cluster-rhcos9-rhcos10/network.md
@@ -12,9 +12,9 @@
 - **Participating SIGs:** sig-virt, sig-network
 
 - **Target Release(s):**
-    DP: N/A
-    TP: v4.22
-    GA: v5.0
+  - DP: N/A
+  - TP: v4.22
+  - GA: v5.0
 
 **Document Conventions:**
 - RHCOS = Red Hat CoreOS, the immutable container-optimized OS used for OpenShift worker nodes.


### PR DESCRIPTION
Mixed RHCOS 9/10 clusters are officially termed "dual-stream", not "heterogeneous"

Make target releases as list for separate lines

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved visual formatting and consistency of release information sections in documentation for better readability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->