### PR TITLE
feat: add child STP template for multi-SIG features

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -289,6 +289,7 @@ stps/sig-iuo/multiarch/
 - The parent STP (`stp.md`) defines the overall scope, requirements, and acceptance criteria
 - Each child STP covers only the participating SIG's test scope — goals, scenarios, and risks
   specific to that SIG
+- Child STPs should follow the child STP template (`stps/stp-template/child-stp.md`)
 - Child STPs reference the parent for shared context (Feature Overview, requirements, acceptance
   criteria) — they do NOT repeat it
 - The feature directory may include an `OWNERS` file listing reviewers from all participating SIGs
@@ -297,6 +298,7 @@ stps/sig-iuo/multiarch/
 ### Child STP Review Checklist
 
 - [ ] Parent STP lists all child STPs in the feature directory with links
+- [ ] Child STP follows the child STP template (`stps/stp-template/child-stp.md`)
 - [ ] Child STP does NOT duplicate Feature Overview, requirements, or acceptance criteria from parent
 - [ ] Child STP defines only the participating SIG's test scope, scenarios, and risks
 - [ ] When a child STP is added to a feature directory that already has a parent STP,

--- a/docs/stp-guide.md
+++ b/docs/stp-guide.md
@@ -44,6 +44,10 @@ stps/<owning-sig>/<feature-name>/
 **Child STPs** — define SIG-specific testing goals, scenarios, strategy, and risks. They reference
 the parent for shared context and do NOT duplicate it.
 
+For child STPs, use the dedicated template: [`stps/stp-template/child-stp.md`](../stps/stp-template/child-stp.md).
+The child template omits sections owned by the parent (Feature Overview, Feature Maturity, Enhancement links)
+and adds a `Parent STP` link for traceability.
+
 Single-SIG features place the STP directly under `stps/<sig>/` without a feature directory.
 
 ### I. Motivation and Requirements Review

--- a/docs/stp-guide.md
+++ b/docs/stp-guide.md
@@ -46,7 +46,7 @@ the parent for shared context and do NOT duplicate it.
 
 For child STPs, use the dedicated template: [`stps/stp-template/child-stp.md`](../stps/stp-template/child-stp.md).
 The child template omits sections owned by the parent (Feature Overview, Feature Maturity, Enhancement links)
-and adds a `Parent STP` link for traceability.
+and references the parent STP from the SIG Scope section for traceability.
 
 Single-SIG features place the STP directly under `stps/<sig>/` without a feature directory.
 

--- a/stps/stp-template/child-stp.md
+++ b/stps/stp-template/child-stp.md
@@ -32,12 +32,12 @@ acceptance criteria, and NFRs are defined in the parent STP. -->
 #### **1. SIG-Specific Requirements**
 
 - [x] **Review Requirements**
-  - *SIG-specific requirements:* [List requirements from the parent that this SIG owns or extends]
+  - *SIG-specific requirements (Jira IDs this SIG covers):* [List Jira IDs from the parent that this SIG owns, or "None — see parent STP"]
 
 - [x] **SIG-Specific Acceptance Criteria**
-  <!-- Only list acceptance criteria that are specific to this SIG's scope.
-  Feature-wide acceptance criteria belong in the parent STP. -->
-  - [List SIG-specific acceptance criteria]
+  <!-- Only list acceptance criteria NEW to this SIG's scope.
+  Do NOT duplicate parent acceptance criteria — reference them by Jira ID instead. -->
+  - [List SIG-specific acceptance criteria not already in the parent, or "None — all covered by parent STP"]
 
 - [x] **Testability**
   - *Note any SIG-specific requirements that are unclear or untestable:* [List or "None"]
@@ -135,7 +135,7 @@ uncheck and state "Covered by parent STP" or "Covered by [SIG name]". -->
   - *Details:* [SIG-specific, or "Covered by parent STP"]
 
 - [ ] **Monitoring**
-  - *Details:* [SIG-specific, or "Covered by parent STP"]
+  - *Details:* [SIG-specific; state whether alerts/metrics are required, or "Covered by parent STP"]
 
 **Integration & Compatibility**
 
@@ -184,7 +184,8 @@ Include only categories where this SIG has a specific risk — omit categories w
 
 ### **III. Test Scenarios & Traceability**
 
-<!-- List only this SIG's test scenarios. Each scenario must trace to a Jira requirement. -->
+<!-- List only this SIG's NEW test scenarios. Each scenario must trace to a Jira requirement.
+Regression tests are documented in Test Strategy (II.2), not in this table. -->
 
 - **[Jira-ID]** — As a [role], I want [action] so that [benefit]
   - *Test Scenario:* [Description]

--- a/stps/stp-template/child-stp.md
+++ b/stps/stp-template/child-stp.md
@@ -7,8 +7,7 @@
 - **Feature Tracking:** [Link to the relevant feature in Jira]
 - **Epic Tracking:** [Link to the SIG-specific tracking Jira Epic, if separate from the parent]
 - **QE Owner(s):** [Name (@github-handle, email)]
-- **Owning SIG:** [The SIG that owns the feature and the parent STP]
-- **Participating SIG:** [This SIG — the one this child STP covers]
+- **SIG:** [This SIG — the one this child STP covers]
 
 **Document Conventions (if applicable):** [Define terms specific to this SIG's scope only]
 
@@ -17,8 +16,7 @@
 <!-- In child STPs: describe this SIG's scope within the parent feature.
 Do NOT repeat the parent's Feature Overview. -->
 
-[Describe what this SIG covers and why it's a separate scope.]
-See the parent STP (`stp.md`) for the full Feature Overview, requirements, and acceptance criteria.
+[Describe what this SIG covers within the feature and why it requires separate test planning.]
 
 ---
 
@@ -30,12 +28,11 @@ Feature-wide requirements, acceptance criteria, and NFRs are defined in the pare
 #### **1. Requirement & User Story Review Checklist**
 
 - [x] **Review Requirements**
-  - *SIG-specific requirements (Jira IDs this SIG covers):* [List Jira IDs from the parent that this SIG owns, or "None — see parent STP"]
+  - *SIG-specific requirements:* [List requirements this SIG owns, or "None — all requirements are in the parent STP"]
 
-- [x] **SIG-Specific Acceptance Criteria**
-  <!-- Only list acceptance criteria NEW to this SIG's scope.
-  Do NOT duplicate parent acceptance criteria — reference them by Jira ID instead. -->
-  - [List SIG-specific acceptance criteria not already in the parent, or "None — all covered by parent STP"]
+- [x] **Acceptance Criteria**
+  <!-- Only list acceptance criteria specific to this SIG's scope. -->
+  - [List SIG-specific acceptance criteria, or "None — all acceptance criteria are in the parent STP"]
 
 - [x] **Testability**
   - *Note any SIG-specific requirements that are unclear or untestable:* [List or "None"]
@@ -63,7 +60,9 @@ If none, state: "None — reviewed and confirmed with [Name/Date]." -->
   - *Impact on testing approach:* [Impact on this SIG's tests]
 
 - [x] **API Extensions**
-  - *List new or modified user-facing APIs:* [SIG-specific APIs, or "None — see parent STP"]
+  <!-- New APIs belong in the parent STP. List here only if this SIG tests existing APIs
+  in a SIG-specific way, otherwise state "N/A — see parent STP". -->
+  - *List new or modified user-facing APIs:* [SIG-specific, or "N/A — see parent STP"]
   - *Testing impact:* [Impact]
 
 - [x] **Test Environment Needs**

--- a/stps/stp-template/child-stp.md
+++ b/stps/stp-template/child-stp.md
@@ -1,0 +1,201 @@
+# Openshift-virtualization-tests Test plan
+
+## **[Feature Title — SIG-Specific Scope] - Quality Engineering Plan**
+
+### **Metadata & Tracking**
+
+- **Feature Tracking:** [Link to the relevant feature in Jira]
+- **Epic Tracking:** [Link to the SIG-specific tracking Jira Epic, if separate from the parent]
+- **QE Owner(s):** [Name (@github-handle, email)]
+- **Owning SIG:** [The SIG that owns the feature and the parent STP]
+- **Participating SIG:** [This SIG — the one this child STP covers]
+
+**Document Conventions (if applicable):** [Define terms specific to this SIG's scope only]
+
+### **SIG Scope**
+
+<!-- 2-4 sentences. State what this SIG is responsible for testing within the parent feature.
+Do NOT repeat the Feature Overview from the parent — reference it instead. -->
+
+This STP covers [SIG name]'s test scope for [feature name].
+See the parent STP for the full Feature Overview, requirements, and acceptance criteria.
+
+[Briefly describe what this SIG tests and why it's a separate scope.]
+
+---
+
+### **I. SIG-Specific Review**
+
+<!-- This section covers only SIG-specific review items. Feature-wide requirements,
+acceptance criteria, and NFRs are defined in the parent STP. -->
+
+#### **1. SIG-Specific Requirements**
+
+- [x] **Review Requirements**
+  - *SIG-specific requirements:* [List requirements from the parent that this SIG owns or extends]
+
+- [x] **SIG-Specific Acceptance Criteria**
+  <!-- Only list acceptance criteria that are specific to this SIG's scope.
+  Feature-wide acceptance criteria belong in the parent STP. -->
+  - [List SIG-specific acceptance criteria]
+
+- [x] **Testability**
+  - *Note any SIG-specific requirements that are unclear or untestable:* [List or "None"]
+
+- [x] **Non-Functional Requirements (NFRs)**
+  <!-- Only list NFRs specific to this SIG's scope. If all NFRs are covered by the parent, state that. -->
+  - *SIG-specific NFRs:* [List or "None — all NFRs are covered by the parent STP"]
+  - *NFRs not covered and why:* [List with justification]
+
+#### **2. Known Limitations**
+
+<!-- List only SIG-specific limitations. Feature-wide limitations belong in the parent STP.
+If none, state: "None — reviewed and confirmed with [Name/Date]." -->
+
+- **[SIG-specific limitation]**
+  - *Sign-off:* [Name/Date]
+
+#### **3. Technology and Design Review**
+
+- [x] **Developer Handoff/QE Kickoff**
+  - *Key takeaways and concerns:* [SIG-specific technical concerns]
+
+- [x] **Technology Challenges**
+  - *List identified challenges:* [SIG-specific challenges]
+  - *Impact on testing approach:* [Impact on this SIG's tests]
+
+- [x] **API Extensions**
+  - *List new or modified APIs:* [SIG-specific APIs, or "None — see parent STP"]
+  - *Testing impact:* [Impact]
+
+- [x] **Test Environment Needs**
+  - *See environment requirements in Section II.3 and testing tools in Section II.3.1*
+
+- [x] **Topology Considerations**
+  - *Describe topology requirements:* [SIG-specific topology needs]
+  - *Impact on test design:* [Impact]
+
+### **II. Software Test Plan (STP)**
+
+#### **1. Scope of Testing**
+
+**Testing Goals**
+
+<!-- List only this SIG's testing goals. Feature-wide goals belong in the parent STP.
+Order by priority: P0 first, then P1, then P2. -->
+
+- **[P0]** [SIG-specific testing goal]
+- **[P1]** [SIG-specific testing goal]
+
+**Out of Scope (Testing Scope Exclusions)**
+
+<!-- List items this SIG explicitly will not test. If something is out of scope for the
+entire feature, it belongs in the parent STP — not here. -->
+
+- **[Item]**
+  - *Rationale:* [Why this SIG won't test it]
+  - *PM/Lead Agreement:* [Name/Date]
+
+**Test Limitations**
+
+<!-- Constraints on this SIG's testing approach. -->
+
+- **[Test Limitation]**
+  - *Sign-off:* [Name/Date]
+
+#### **2. Test Strategy**
+
+<!-- Mark items that this SIG will test. For items covered by the parent STP or other SIGs,
+uncheck and state "Covered by parent STP" or "Covered by [SIG name]". -->
+
+**Functional**
+
+- [ ] **Functional Testing**
+  - *Details:* [SIG-specific functional testing approach]
+
+- [ ] **Automation Testing**
+  - *Details:* [SIG-specific automation plan]
+
+- [ ] **Regression Testing**
+  - *Details:* [Which existing SIG test suites run on the feature cluster]
+
+**Non-Functional**
+
+- [ ] **Performance Testing**
+  - *Details:* [SIG-specific, or "Covered by parent STP"]
+
+- [ ] **Scale Testing**
+  - *Details:* [SIG-specific, or "Covered by parent STP"]
+
+- [ ] **Security Testing**
+  - *Details:* [SIG-specific, or "Covered by parent STP"]
+
+- [ ] **Usability Testing**
+  - *Details:* [SIG-specific, or "Covered by parent STP"]
+
+- [ ] **Monitoring**
+  - *Details:* [SIG-specific, or "Covered by parent STP"]
+
+**Integration & Compatibility**
+
+- [ ] **Compatibility Testing**
+  - *Details:* [SIG-specific, or "Not applicable for this STP"]
+
+- [ ] **Upgrade Testing**
+  - *Details:* [SIG-specific, or "Covered by parent STP"]
+
+- [ ] **Dependencies**
+  - *Details:* [SIG-specific blocking dependencies]
+
+- [ ] **Cross Integrations**
+  - *Details:* [SIG-specific, or "Covered by parent STP"]
+
+**Infrastructure**
+
+- [ ] **Cloud Testing**
+  - *Details:* [SIG-specific, or "Not applicable"]
+
+#### **3. Test Environment**
+
+<!-- Covered in the parent STP; make sure it includes the SIG's specific requirements. -->
+
+#### **3.1. Testing Tools & Frameworks**
+
+- **Test Framework:** Standard
+
+- **CI/CD:** [SIG-specific CI lanes, or N/A]
+
+- **Other Tools:** N/A
+
+#### **4. Risks**
+
+<!-- List only SIG-specific risks. Feature-wide risks belong in the parent STP. 
+Include only categories where this SIG has a specific risk — omit categories with no SIG-specific risk. -->
+
+**[Risk Category]**
+
+- **Risk:** [SIG-specific risk]
+  - **Mitigation:** [Mitigation plan]
+  - *[Category-specific field]:* [Details]
+  - *Sign-off:* [Name/Date]
+
+---
+
+### **III. Test Scenarios & Traceability**
+
+<!-- List only this SIG's test scenarios. Each scenario must trace to a Jira requirement. -->
+
+- **[Jira-ID]** — As a [role], I want [action] so that [benefit]
+  - *Test Scenario:* [Tier N] [Description]
+  - *Priority:* P0
+
+---
+
+### **IV. Sign-off and Approval**
+
+This Software Test Plan requires approval from the following stakeholders:
+
+* **Reviewers:**
+  - [Name / @github-handle]
+* **Approvers:**
+  - [Name / @github-handle]

--- a/stps/stp-template/child-stp.md
+++ b/stps/stp-template/child-stp.md
@@ -12,24 +12,22 @@
 
 **Document Conventions (if applicable):** [Define terms specific to this SIG's scope only]
 
-### **SIG Scope**
+### **Feature Overview**
 
-<!-- 2-4 sentences. State what this SIG is responsible for testing within the parent feature.
-Do NOT repeat the Feature Overview from the parent — reference it instead. -->
+<!-- In child STPs: describe this SIG's scope within the parent feature.
+Do NOT repeat the parent's Feature Overview. -->
 
-This STP covers [SIG name]'s test scope for [feature name].
-See the parent STP for the full Feature Overview, requirements, and acceptance criteria.
-
-[Briefly describe what this SIG tests and why it's a separate scope.]
+[Describe what this SIG covers and why it's a separate scope.]
+See the parent STP (`stp.md`) for the full Feature Overview, requirements, and acceptance criteria.
 
 ---
 
-### **I. SIG-Specific Review**
+### **I. Motivation and Requirements Review (QE Review Guidelines)**
 
-<!-- This section covers only SIG-specific review items. Feature-wide requirements,
-acceptance criteria, and NFRs are defined in the parent STP. -->
+<!-- In child STPs: this section covers only SIG-specific review items.
+Feature-wide requirements, acceptance criteria, and NFRs are defined in the parent STP. -->
 
-#### **1. SIG-Specific Requirements**
+#### **1. Requirement & User Story Review Checklist**
 
 - [x] **Review Requirements**
   - *SIG-specific requirements (Jira IDs this SIG covers):* [List Jira IDs from the parent that this SIG owns, or "None — see parent STP"]
@@ -168,7 +166,11 @@ uncheck and state "Covered by parent STP" or "Covered by [SIG name]". -->
 
 - **Other Tools:** N/A
 
-#### **4. Risks**
+#### **4. Entry Criteria**
+
+<!-- Covered by the parent STP. Add SIG-specific entry criteria only if needed. -->
+
+#### **5. Risks**
 
 <!-- List only SIG-specific risks. Feature-wide risks belong in the parent STP.
 Include only categories where this SIG has a specific risk — omit categories with no SIG-specific risk. -->

--- a/stps/stp-template/child-stp.md
+++ b/stps/stp-template/child-stp.md
@@ -65,7 +65,7 @@ If none, state: "None — reviewed and confirmed with [Name/Date]." -->
   - *Impact on testing approach:* [Impact on this SIG's tests]
 
 - [x] **API Extensions**
-  - *List new or modified APIs:* [SIG-specific APIs, or "None — see parent STP"]
+  - *List new or modified user-facing APIs:* [SIG-specific APIs, or "None — see parent STP"]
   - *Testing impact:* [Impact]
 
 - [x] **Test Environment Needs**
@@ -86,6 +86,7 @@ Order by priority: P0 first, then P1, then P2. -->
 
 - **[P0]** [SIG-specific testing goal]
 - **[P1]** [SIG-specific testing goal]
+- **[P2]** [SIG-specific testing goal]
 
 **Out of Scope (Testing Scope Exclusions)**
 
@@ -169,7 +170,7 @@ uncheck and state "Covered by parent STP" or "Covered by [SIG name]". -->
 
 #### **4. Risks**
 
-<!-- List only SIG-specific risks. Feature-wide risks belong in the parent STP. 
+<!-- List only SIG-specific risks. Feature-wide risks belong in the parent STP.
 Include only categories where this SIG has a specific risk — omit categories with no SIG-specific risk. -->
 
 **[Risk Category]**
@@ -186,8 +187,9 @@ Include only categories where this SIG has a specific risk — omit categories w
 <!-- List only this SIG's test scenarios. Each scenario must trace to a Jira requirement. -->
 
 - **[Jira-ID]** — As a [role], I want [action] so that [benefit]
-  - *Test Scenario:* [Tier N] [Description]
-  - *Priority:* P0
+  - *Test Scenario:* [Description]
+  - *Tier:* [1 or 2]
+  - *Priority:* [P0/P1/P2]
 
 ---
 
@@ -198,4 +200,6 @@ This Software Test Plan requires approval from the following stakeholders:
 * **Reviewers:**
   - [Name / @github-handle]
 * **Approvers:**
-  - [Name / @github-handle]
+  - [QE Lead Name / @github-handle]
+  - [PM Name / @github-handle]
+  - [Dev Lead Name / @github-handle]


### PR DESCRIPTION
## Summary

Add a dedicated template for child STPs (`stps/stp-template/child-stp.md`) that participating SIGs use when a feature spans multiple SIGs.

## What's in the child template

The child template is a streamlined version of the parent STP template, tailored for participating SIGs:

- **Adds** `Owning SIG` and `Participating SIG` to metadata
- **Adds** a `SIG Scope` section (replaces Feature Overview — references the parent instead of duplicating it)
- **Omits** sections owned by the parent: Feature Overview, Feature Maturity, Enhancement links, Entry Criteria, full Test Environment
- **Keeps** SIG-specific sections: requirements, acceptance criteria, testing goals, scenarios, strategy, risks, and sign-off
- **Defers** Test Environment to the parent STP with a note to ensure SIG-specific needs are included

## Other changes

- **AGENTS.md**: Added child template reference to the rules list and review checklist
- **docs/stp-guide.md**: Added child template reference in the Multi-SIG Features section

## Reference

The existing child STP in the repo (`stps/sig-virt/heterogeneous-rhcos9-rhcos10/network.md` from PR #65) follows this pattern.

Assisted-by: Claude <noreply@anthropic.com>

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a comprehensive child Software Test Plan (STP) template with SIG-specific quality engineering sections.
  * Introduced explicit compliance requirements for child STP authors and added checklist gates for reviewers.
  * Clarified child STPs must omit parent-owned content and reference the parent STP for traceability.
  * Template includes requirements, prioritized testing strategy, risks, Jira-traceable test scenarios, and approval sign-offs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->