### PR TITLE
Remove duyanyan from sig-storage OWNERS

### DIFF
--- a/stps/sig-storage/OWNERS
+++ b/stps/sig-storage/OWNERS
@@ -2,7 +2,6 @@ root-approvers: False
 approvers:
   - jpeimer
 reviewers:
-  - duyanyan
   - jpeimer
   - josemacassan
   - kgoldbla


### PR DESCRIPTION
Remove duyanyan from the sig-storage reviewers list 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal code review team assignments.

---

**Note:** This release contains internal administrative changes only and does not impact user-facing functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/RedHatQE/openshift-virtualization-tests-design-docs/pull/102)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->