### PR TITLE
sig-virt: Update OWNERS with dev and PM reviewers

### DIFF
--- a/stps/sig-virt/OWNERS
+++ b/stps/sig-virt/OWNERS
@@ -7,3 +7,5 @@ reviewers:
   - vsibirsk
   - akri3i
   - SamAlber
+  - jean-edouard
+  - mtessun


### PR DESCRIPTION
Add jean-edouard (Jed Lejosne) as dev reviewer and mtessun (Martin Tessun) as PM reviewer for sig-virt STPs. 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated review ownership assignments for one area of the project by adding two additional reviewers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->