### PR TITLE
update dual stream stp for cnv-5.0

### DIFF
--- a/stps/sig-virt/dual-stream-cluster-rhcos9-rhcos10/stp.md
+++ b/stps/sig-virt/dual-stream-cluster-rhcos9-rhcos10/stp.md
@@ -1,21 +1,27 @@
 # Openshift-virtualization-tests Test plan
 
-## **Dual-Stream RHCOS Support (RHCOS9.8 + RHCOS10.2 Worker Nodes) — Quality Engineering Plan**
+## **Dual-Stream RHCOS Support (RHCOS9.x + RHCOS10.x Worker Nodes) — Quality Engineering Plan**
 
 ### **Metadata & Tracking**
 
-- **Enhancement(s):** https://redhat.atlassian.net/browse/VIRTSTRAT-83
+- **Enhancement(s):** https://issues.redhat.com/browse/VIRTSTRAT-83
 - **Feature Tracking:** No separate VEP/HLD; tracked via VIRTSTRAT-83
-- **Epic Tracking:** https://redhat.atlassian.net/browse/CNV-49964
-- **QE Owner(s):** Akriti Gupta
+- **Epic Tracking:** https://issues.redhat.com/browse/CNV-84749
+- **QE Owner(s):** Akriti Gupta (@akri3i)
 - **Readiness Tracking:** [RHCOS 10 Readiness Tracking](https://docs.google.com/spreadsheets/d/1mD1mVkiIqrdyaDIqB0fhRgmywWp4sI9OEy0IVBD6pDc/edit?gid=0#gid=0)
 - **Owning SIG:** sig-virt
 - **Participating SIGs:** sig-virt, sig-network, sig-storage, sig-iuo, sig-infra
+- **Child STPs:**
+  - [sig-network](./network.md) — QE Owner: Asia Khromov (@azhivovk)
+  - [sig-storage](./storage.md) — QE Owner: Kate Shvaika (@kshvaika)
+  - sig-iuo — QE Owner: Ohad Revah (@OhadRevah) — child STP: [PR #108](https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/pull/108) (not yet merged)
+  - sig-infra — tracked in [CNV-86242](https://redhat.atlassian.net/browse/CNV-86242); child STP not yet created
+  - sig-virt — covered by this parent STP (no separate child STP)
 
 - **Target Release(s):**
   - DP: N/A
-  - TP: v4.22 — RHCOS 10.2 worker node support is Tech Preview
-  - GA: v5.0 — RHCOS 10.2 support GA
+  - TP: v4.22 — RHCOS 10.x worker node support is Tech Preview
+  - GA: v5.0 — RHCOS 10.x support GA
 
 > **This is a Parent STP.** It defines the overall dual-stream RHCOS testing strategy and cross-cutting
 > requirements. Each participating SIG is expected to create a child STP that extends this document with
@@ -24,15 +30,18 @@
 
 **Document Conventions:**
 
-- **RHCOS9.8:** Red Hat CoreOS 9.8 worker nodes (GA, default for OCP 4.22).
-- **RHCOS10.2:** Red Hat CoreOS 10.2 worker nodes (Tech Preview in 4.22, GA in 5.0).
-- **Dual-stream cluster:** An OCP cluster running both RHCOS9.8 and RHCOS10.2 worker nodes simultaneously.
+- **RHCOS9.x:** Red Hat CoreOS 9.x worker nodes (supported alongside RHCOS 10.x through CNV 5.2).
+- **RHCOS10.x:** Red Hat CoreOS 10.x worker nodes (Tech Preview in 4.22, GA and default from 5.0).
+- **Dual-stream cluster:** An OCP cluster running both RHCOS9.x and RHCOS10.x worker nodes simultaneously.
 
 ### **Feature Overview**
 
-Starting with OCP 4.22, OpenShift Virtualization supports dual-stream clusters running both RHCOS 9.8 and RHCOS 10.2 worker nodes.
-This enables customers to gradually migrate their worker nodes to RHCOS 10 while maintaining VM workload availability through live migration across node types.
-RHCOS 9.8 remains the default for OCP 4.22.
+OpenShift Virtualization supports dual-stream clusters running both RHCOS 9.x and RHCOS 10.x
+worker nodes in the same cluster. Customers can keep mixed worker OS versions and move VM
+workloads between node types with live migration while gradually adopting RHCOS 10.
+
+This STP validates 5.0; the feature is supported through 5.2.
+RHCOS 10.x is the default worker OS in 5.0. Tech Preview dual-stream support began in 4.22.
 
 ---
 
@@ -42,32 +51,40 @@ RHCOS 9.8 remains the default for OCP 4.22.
 
 - [x] **Review Requirements**
   - *Key requirements reviewed:*
-    - CNV 4.22: RHCOS9.8 is GA/default; RHCOS10.2 is Tech Preview.
+    - CNV 4.22 / 4.23 (Tech Preview): RHCOS9.x is GA/default; RHCOS10.x is Tech Preview.
+      Covered by the earlier 4.22-era STP work — **out of scope for this STP**.
+    - CNV 5.0: RHCOS10.x is GA/default; RHCOS9.x remains supported for dual-stream and
+      RHCOS 9.x-only clusters through CNV 5.2.
     - OCPSTRAT-1150: Support dual-stream clusters to
       allow customers to run mixed hardware. VM live migration must succeed across
-      RHCOS9.8 ↔ RHCOS10.2 worker nodes.
+      RHCOS9.x ↔ RHCOS10.x worker nodes.
 
 - [x] **Understand Value and Customer Use Cases**
   - *Feature value to customers:* Customers can run mixed hardware in the same cluster — newer
     hardware that requires RHEL 10 and older hardware that only supports RHEL 9.
   - *Customer use cases:*
-    - As a cluster administrator, I want to add RHCOS10.2 worker nodes to my existing
+    - As a cluster administrator, I want to add RHCOS10.x worker nodes to my existing
       cluster.
-    - As a VM operator, I want to live-migrate VMs from RHCOS9.8 worker nodes to RHCOS10.2 worker
+    - As a VM operator, I want to live-migrate VMs from RHCOS9.x worker nodes to RHCOS10.x worker
       nodes.
-    - As a platform team, I want to validate that CNV behaves correctly on both RHCOS9.8 and RHCOS10.2
+    - As a platform team, I want to validate that CNV behaves correctly on both RHCOS9.x and RHCOS10.x
       nodes.
 
 - [x] **Acceptance Criteria**
   - *Acceptance criteria:*
-    - All CNV features available on RHCOS 9.8 clusters work identically on RHCOS 10.2 clusters.
-    - All CNV features work identically on dual-stream clusters.
-    - A VM running on an RHCOS9.8 worker node can be live-migrated to an RHCOS10.2 worker node and
-      back without disruption.
-    - A VM running on an RHCOS10.2 worker node can be live-migrated to an RHCOS9.8 worker node and
-      back without disruption.
-    - CNV components deploy and report ready status on RHCOS 10.2 worker nodes with the same
-      behavior as on RHCOS 9.8 nodes.
+    - CNV features on dual-stream clusters behave as on single-OS clusters — validated by existing
+      Tier 1/2/3 suites; SIG-specific coverage documented in child STPs.
+    - A VM on an RHCOS9.x worker can be live-migrated to an RHCOS10.x worker and back:
+      VM remains in Running phase throughout migration, a guest workload started before
+      migration continues running after migration without restart, and the VM is accessible
+      on the target node — validated by CNV-81251 scenarios in Section III.
+    - A VM on an RHCOS10.x worker can be live-migrated to an RHCOS9.x worker and back:
+      VM remains in Running phase throughout migration, a guest workload started before
+      migration continues running after migration without restart, and the VM is accessible
+      on the target node — validated by CNV-81251 scenarios in Section III.
+    - Single-stream RHCOS 9.x-only coverage (supported through CNV 5.2) is provided by existing
+      Tier 1/2/3 regression suites from participating SIGs (see Testing Goals / Regression
+      Testing) — not by new Section III scenarios.
 
 - [x] **Non-Functional Requirements (NFRs)**
   - *Applicable NFRs:*
@@ -76,8 +93,10 @@ RHCOS 9.8 remains the default for OCP 4.22.
     - **Monitoring/Observability:** N/A — no new alerts or metrics introduced; existing CNV monitoring applies unchanged.
     - **Scalability:** N/A — no new scale requirements; existing cluster-level live migration parallelism limits apply.
     - **UI:** N/A — no UI code changes introduced; UI testing adds no customer value for this feature.
-    - **Documentation:** Release notes must document RHCOS10.2 Tech Preview status in 4.22 and GA status timeline.
-    - **Compatibility:** N/A — validated via Tier 1/2/3 runs on both RHCOS9.8 and RHCOS10.2.
+    - **Documentation:** Release notes must document RHCOS10.x Tech Preview status in 4.22 and GA status timeline.
+    - **Compatibility:** Required — CNV must remain compatible with RHCOS 9.x, RHCOS 10.x, and
+      dual-stream clusters. Validated via existing Tier 1/2/3 suites on both node types, plus
+      dual-stream live migration scenarios in Section III. SIG-specific coverage is in child STPs.
 
 
 #### **2. Technology and Design Review**
@@ -90,15 +109,17 @@ RHCOS 9.8 remains the default for OCP 4.22.
 
 - [x] **Technology Challenges**
   - *Identified challenges:*
-    - **CNV compatibility on RHCOS 10.2:** RHCOS 10.2 is a new platform configuration that may
+    - **CNV compatibility on RHCOS 10.x:** RHCOS 10.x is a new platform configuration that may
       surface unexpected failures. Tier 1, Tier 2, and Tier 3 testing is the primary mechanism for
       finding these issues.
-    - **Dual-stream cluster provisioning:** Clusters with mixed RHCOS9.8 and RHCOS10.2 worker
-      nodes require specific provisioning tooling. DevOps QE to provide this capability.
+    - **Dual-stream cluster provisioning:** Clusters with mixed RHCOS9.x and RHCOS10.x worker
+      nodes require specific provisioning tooling. QE DevOps has provided this capability
+      and it is validated and available for test use.
 
   - *Impact on testing approach:*
-    - Tier 1, Tier 2, and Tier 3 testing on an RHCOS10.2-only cluster is mandatory for all component
-      teams — this is the primary testing vehicle.
+    - Tier 1, Tier 2, and Tier 3 testing on an RHCOS10.x-only cluster is default in CNV-5.0.
+    - Since RHCOS9.x is still supported in 5.0, testing should also cover RHCOS9.x-only clusters;
+      component teams decide which tests to run.
     - Each participating SIG decides which tests to run on dual-stream clusters based on their
       feature area requirements.
     - Live migration across RHCOS versions must be tested explicitly.
@@ -112,22 +133,23 @@ RHCOS 9.8 remains the default for OCP 4.22.
 
 - [x] **Topology Considerations**
   - *Topology requirements:*
-    - FOR RHCOS 10.2:
+    - FOR RHCOS 10.x:
       - Either high-availability (HA) or a compact cluster
-      - Requires both control plane and worker nodes to be on RHCOS 10.2
+      - Requires both control plane and worker nodes to be on RHCOS 10.x
+    - FOR RHCOS 9.x:
+      - Either high-availability (HA) or a compact cluster
+      - Requires both control plane and worker nodes to be on RHCOS 9.x
     - For OCPSTRAT-1150:
-      - Dual-stream testing requires only a high-availability (HA)
-        cluster — at least 1 worker running RHCOS10.2 alongside RHCOS9.8 workers
+      - Dual-stream testing requires a high-availability (HA) bare-metal
+        cluster — at least 1 worker running RHCOS10.x alongside RHCOS9.x workers
         within the same OCP cluster.
-
 ---
 
 #### **3. Known Limitations**
 
-- **CNV on RHCOS 10.2 worker nodes uses the same software stack as on RHCOS 9.8
-  through OCP 5.2.** A fully RHCOS 10-native CNV stack is planned for OCP 5.3
-  and is out of scope for this STP.
-  - *Sign-off:* Martin Tessun / 2026-05-13
+- **CNV on RHCOS 10.x worker nodes uses the same software stack as on RHCOS 9.x
+  through CNV 5.2.** A fully RHCOS 10-native CNV stack is planned for OCP 5.3
+  (testing decision and sign-off in Out of Scope, Section II.1).
 
 ---
 
@@ -137,14 +159,17 @@ RHCOS 9.8 remains the default for OCP 4.22.
 
 **Testing Goals**
 
-- **[P0]** As a cluster admin, I can run all supported VM workloads on an RHCOS 10.2-only cluster
-  with the same behavior as on RHCOS 9.8.
-- **[P1]** As a cluster admin, I can operate a dual-stream cluster (RHCOS 9.8 + RHCOS 10.2 worker
+- **[P1] [Regression]** On an RHCOS 9.x-only cluster (supported through CNV 5.2), existing
+  Tier 1/2/3 suites from sig-virt, sig-network, sig-storage, sig-iuo, and sig-infra run as
+  decided by each SIG. No new single-stream tests; coverage is regression.
+- **[P1]** As a cluster admin, I can operate a dual-stream cluster (RHCOS 9.x + RHCOS 10.x worker
   nodes) and all supported VM workloads function correctly on both node types.
-- **[P1]** As a VM operator, I can live-migrate a VM from an RHCOS 9.8 worker node to an RHCOS 10.2
-  worker node and back without disruption, and vice versa.
-- **[P1]** As a cluster admin, CNV components deploy and report ready on RHCOS 10.2 worker nodes
-  with the same behavior as on RHCOS 9.8 nodes.
+- **[P1]** As a VM operator, I can live-migrate a VM from an RHCOS 9.x worker node to an RHCOS 10.x
+  worker node and back (and vice versa): the VM remains in Running phase throughout migration,
+  a guest workload started before migration continues running after migration without restart,
+  and the VM is accessible on the target node.
+
+
 **Out of Scope (Testing Scope Exclusions)**
 
 - **Fully RHCOS 10-native CNV stack**
@@ -152,13 +177,16 @@ RHCOS 9.8 remains the default for OCP 4.22.
     testing effort. This STP covers only dual-stream support through OCP 5.2.
   - *PM/Lead Agreement:* Martin Tessun / 2026-05-13
 
+- **Upgrade testing**
+  - *Rationale:* This STP validates CNV 5.0. Upgrade testing is relevant only
+    from 5.1.0.
+  - *PM/Lead Agreement:* Martin Tessun / 2026-05-13
+
 
 **Test Limitations**
 
-- **Dual-stream cluster provisioning depends on QE DevOps tooling.** The ability to deploy
-  a cluster with mixed RHCOS9.8 and RHCOS10.2 worker nodes relies on tooling provided by the
-  QE DevOps team. If this tooling is unavailable or unstable, the dual-stream migration
-  scenarios cannot be executed.
+- None — dual-stream cluster provisioning tooling from QE DevOps is validated and available
+  (see Dependencies in Section II.2 and Entry Criteria in Section II.4).
   - *Sign-off:* Martin Tessun / 2026-05-13
 
 
@@ -167,28 +195,38 @@ RHCOS 9.8 remains the default for OCP 4.22.
 **Functional**
 
 - [x] **Functional Testing**
-  - Validates that the full CNV feature set operates correctly on RHCOS10.2-only clusters
-  - *Details:* The primary mechanism is running existing Tier1, Tier 2 and Tier 3 test suites and triaging failures.
-  - All other SIGs (sig-network, sig-storage, sig-iuo, sig-infra) must document
-    their Tier1, Tier 2 and Tier 3 Test results and bugs in their own Jira Stories.
-  - For OCPSTRAT-1150: Validates that the full CNV feature set operates correctly on dual-stream clusters, with el9.8 userspace.
-    - VM live migration must succeed across RHCOS9.8 ↔ RHCOS10.2 worker nodes.
-      - Successful LiveMigration of VM from RHCOS9.8 to RHCOS10.2 worker node and backto RHCOS9.8
-          i.e VM created first on RHCOS9.8 Worker Node
-      - Successful LiveMigration of VM from RHCOS10.2 to RHCOS9.8 worker node and backto RHCOS10.2
-          i.e VM created first on RHCOS10.2 Worker Node
+  - For OCPSTRAT-1150: Validates that the full CNV feature set operates correctly on dual-stream clusters.
+    - VM live migration must succeed across RHCOS9.x ↔ RHCOS10.x worker nodes.
+      - Successful live migration of a VM from an RHCOS9.x worker node to an RHCOS10.x worker
+        node and back to RHCOS9.x — that is, the VM is created first on an RHCOS9.x worker node
+      - Successful live migration of a VM from an RHCOS10.x worker node to an RHCOS9.x worker
+        node and back to RHCOS10.x — that is, the VM is created first on an RHCOS10.x worker node
+  - Single-stream RHCOS 9.x-only coverage is **regression** for this STP (see Regression
+    Testing and Testing Goals).
 
-- [ ] **Automation Testing**
-  - For RHCOS 10.2: No new automation tests needed — existing Tier 1, Tier 2 and Tier 3 suites
-    are run as-is.
-  - For OCPSTRAT-1150 (dual-stream live migration): Manual ad-hoc runs for 4.22 Tech Preview;
-    node-affinity-based automation in Tier 2 by 5.0 GA.
+- [x] **Automation Testing**
+  - For RHCOS 9.x single-stream regression: No new automation — existing Tier 1, Tier 2,
+    and Tier 3 suites are run as-is as decided by each SIG.
+  - For OCPSTRAT-1150 (dual-stream live migration): Automation is **done** for sig-virt
+    (CNV-81251 scenarios in this parent STP), sig-network, and sig-infra. sig-storage and
+    sig-iuo automation is **not done**; sig-storage tracks remaining work in
+    [storage.md](./storage.md), and sig-iuo tracks remaining work in
+    [PR #108](https://github.com/RedHatQE/openshift-virtualization-tests-design-docs/pull/108).
 
-- [x] **Regression Testing** — sig-virt and all participating SIGs must run Tier1, Tier 2 and Tier 3
-  regression
-  - On RHCOS10.2-only cluster.
-    - *Details:* The strategy relies on running existing Tier 1, Tier 2 and Tier 3 test suites against RHCOS 10.2
-  - For OCPSTRAT-1150: See Automation Testing above for the decision and rationale.
+- [x] **Regression Testing** — RHCOS 9.x-only single-stream coverage for this STP.
+  - *SIG suites:* sig-virt, sig-network, sig-storage, sig-iuo, and sig-infra each run their
+    existing Tier 1, Tier 2, and Tier 3 suites on RHCOS 9.x-only as decided by each SIG.
+    Each SIG documents results/bugs in their own Jira stories / child STPs.
+  - On RHCOS9.x-only cluster (supported through CNV 5.2):
+    - *Details:* Run existing Tier 1, Tier 2, and Tier 3 test suites against RHCOS 9.x
+      as decided by each participating SIG.
+  - On RHCOS10.x-only cluster: RHCOS 10.x is the CNV 5.0 default; existing Tier 1/2/3 suites
+    already run there as standard product CI. Not a Testing Goal of this STP.
+  - For OCPSTRAT-1150: see Automation Testing above.
+  - Regression coverage is **not** listed in Section III.
+- [ ] **Self-Validation Testing**
+  - *Details:* N/A. RHCOS 10.x-only and dual-stream scenarios require specialized cluster
+    configurations not available in self-validation environments.
 
 **Non-Functional**
 
@@ -204,30 +242,29 @@ RHCOS 9.8 remains the default for OCP 4.22.
 
 **Integration & Compatibility**
 
-- [x] **Compatibility Testing** — CNV must remain compatible with both RHCOS9.8 and RHCOS10.2
-  across the supported version range (4.22 through 5.2).
-  - *Details:* Compatibility is validated through Tier 1, Tier 2 and Tier 3 runs on both RHCOS9.8 and RHCOS10.2
-    clusters. Component teams validate their specific feature areas in child STPs.
+- [x] **Compatibility Testing** — CNV must remain compatible with both RHCOS9.x and RHCOS10.x.
+  - *Details:* Compatibility is validated through Tier 1, Tier 2, and Tier 3 runs on both RHCOS9.x
+    and RHCOS10.x clusters for OCP/CNV 5.0. This STP validates 5.0; the feature is supported
+    through 5.2. 4.22/4.23 Tech Preview coverage is handled by the earlier 4.22-era STP.
+    Component teams validate their specific feature areas in child STPs.
 
-- [x] **Upgrade Testing** — Out of scope for this 4.22 STP.
-  - *Details:* Upgrade testing (4.22 → 5.0, EUS-to-EUS, etc.) will be covered in the 5.0 .
-    Not planned as part of 4.22 testing.
+- [ ] **Upgrade Testing** — Out of scope for this STP.
+  - *Details:* Relevant only from 5.1.0.
+  - *PM/Lead Agreement:* Martin Tessun / 2026-05-13
 
-- [x] **Dependencies** — Testing is blocked on specific deliverables from other teams.
-  - *Details:* QE DevOps team must provide a stable dual-stream cluster provisioning option
-      (RHCOS9.8 + RHCOS10.2 workers in the same cluster).
+- [x] **Dependencies** — Resolved.
+  - *Details:* QE DevOps team has provided dual-stream cluster provisioning
+      (RHCOS9.x + RHCOS10.x workers in the same cluster).
 
-- [x] **Cross Integrations** — Other SIGs must create a child STP extending this one to cover adhoc testing for OCPSTRAT-1150.
+- [x] **Cross Integrations** — Other SIGs must create a child STP extending this one to cover testing for OCPSTRAT-1150.
   - *Details:* sig-network, sig-storage, sig-iuo, and sig-infra must each create child STPs
-    specifying their Tier 1, Tier 2 and Tier 3 test coverage on RHCOS10.2 nodes and dual-stream
-    clusters. Each SIG is responsible for triaging failures in their area and filing bugs
-    with clear RHCOS-version attribution.
+    specifying their Tier 1, Tier 2 and Tier 3 test coverage on RHCOS10.x nodes and dual-stream
+    clusters.
 
 **Infrastructure**
 
-- [x] **Cloud Testing**
-  — For 4.22 Tech Preview we must test with FIPS enabled.
-  - Use cloud setup if it supports FIPS enabled
+- [ ] **Cloud Testing**
+  - *Details:* N/A. Dual-stream testing requires an HA bare-metal cluster.
 
 #### **3. Test Environment**
 
@@ -235,12 +272,16 @@ RHCOS 9.8 remains the default for OCP 4.22.
 
 - **Cluster Topology:**
   - **Dual-stream testing:** High-availability (HA) bare-metal cluster required —
-    3-control-plane / 3-worker minimum, with at least 1 worker running RHCOS10.2 alongside
-    RHCOS9.8 workers. SNO or compact clusters are not supported for dual-stream testing.
-  - **RHCOS10.2-only testing:** Standard 3-control-plane / 3-worker bare-metal cluster with all
-    workers on RHCOS10.2.
+    3-control-plane / 3-worker minimum, with at least 1 worker running RHCOS10.x alongside
+    RHCOS9.x workers. SNO or compact clusters are not supported for dual-stream testing.
+  - **RHCOS10.x-only testing:** Standard 3-control-plane / 3-worker bare-metal cluster with all
+    workers on RHCOS10.x.
+  - **RHCOS9.x-only testing:** Standard 3-control-plane / 3-worker bare-metal cluster with all
+    workers on RHCOS9.x (supports P1 single-stream regression goal).
 
-- **OCP & OpenShift Virtualization Version(s):** OCP 4.22 with CNV 4.22
+- **OCP & OpenShift Virtualization Version(s):** OCP 5.0 with CNV 5.0. This STP validates 5.0;
+  the feature is supported through 5.2. 4.22/4.23 Tech Preview is covered by the earlier
+  4.22-era STP.
 
 - **CPU Virtualization:** Standard (VT-x / AMD-V enabled)
 
@@ -254,20 +295,19 @@ RHCOS 9.8 remains the default for OCP 4.22.
 
 - **Required Operators:** Standard.
 
-- **Platform:** Bare metal (dual-stream cluster provisioned by DevOps QE tooling).
+- **Platform:** Bare metal. Dual-stream cluster provisioned by QE DevOps tooling.
 
-- **Special Configurations:** Dual-stream cluster. DevOps QE
-  provides tooling to deploy this configuration.
+- **Special Configurations:** Dual-stream cluster with FIPS enabled. QE DevOps dual-stream
+  provisioning tooling is validated and available to deploy this configuration.
 
 #### **3.1. Testing Tools & Frameworks**
 
 - **Test Framework:**
-  - Standard (openshift-virtualization-tests) for RHCOS 10.2
-  - For OCPSTRAT-1150 (dual-stream): See Automation Testing in Section II.2 for the decision and rationale.
-
+  - Standard (openshift-virtualization-tests) for RHCOS 10.x
+  - For OCPSTRAT-1150 (dual-stream): see Automation Testing in Section II.2.
 - **CI/CD:** Two cluster configurations are required, both available from CNV 4.22:
-  - **RHCOS10.2-only cluster:** Existing Tier 1, Tier 2 and Tier 3 jobs run by all component teams.
-  - **Dual-stream cluster :** Manual ad-hoc live migration runs by component teams.
+  - **RHCOS10.x-only cluster:** Existing Tier 1, Tier 2 and Tier 3 jobs run by all component teams.
+  - **Dual-stream cluster:** See Automation Testing (Section II.2) for per-SIG automation status.
 
 - **Other Tools:** N/A
 
@@ -279,8 +319,8 @@ The following conditions must be met before testing can begin:
   (recommendation doc sign-offs from PM, Engineering, Platform, Product Ops confirmed)
 - [x] Test environment can be **set up and configured** (dual-stream cluster available via
   QE DevOps tooling)
-- [x] **CNV 4.22 builds based on RHCOS 9.8 are available and validated**
 - [x] QE DevOps dual-stream cluster provisioning is validated and available
+- [x] CNV 5.0 defaults to RHCOS 10.x worker nodes
 
 #### **5. Risks**
 
@@ -292,25 +332,22 @@ The following conditions must be met before testing can begin:
 
 **Test Coverage**
 
-- **Risk:** None identified.
-  - **Mitigation:** All intentional coverage exclusions are documented in Out of Scope (Section II.1).
-    Each participating SIG covers their own feature area via child STPs.
-  - *Areas with reduced coverage:* N/A
+- **Risk:** sig-storage and sig-iuo dual-stream automation is not done. Remaining
+  coverage depends on those SIGs landing automation tracked in their child STPs
+  (see Automation Testing, Section II.2). Target: CNV 5.0 GA.
+  - **Mitigation:** See Automation Testing (Section II.2) for tracking links.
+  - *Areas with reduced coverage:* Dual-stream automation for sig-storage and sig-iuo
+    until those child STPs record the work as done.
+  - *Sign-off:* Martin Tessun / 2026-05-13
 
 **Test Environment**
 
 - **Risk:**
   - HA resource shortage.
-  - RDU2 to RDU3 migration, bare metal cluster outages.
-  - Deploying RHCOS 10.2 and Dual-Stream cluster on cloud fails (PSI, IBM-BM or other clouds with FIPS fails).
-  - QE DevOps dual-stream cluster provisioning tooling may be unavailable or unstable, blocking
-    Tier 1, Tier 2 and Tier 3 runs.
   - **Mitigation:**
-    - Use bare metal cluster with FIPS enabled.
-    - Engage QE DevOps team early to confirm dual-stream cluster availability timeline. Identify a
-      fallback of manually provisioning a mixed-node cluster if tooling is delayed. Track
-      provisioning readiness as an entry criterion.
-  - *Missing or unavailable environments:* Dual-stream cluster if QE DevOps tooling is not ready.
+    - Use QE DevOps dual-stream HA bare-metal provisioning and coordinate cluster
+      capacity for dual-stream runs.
+  - *Missing or unavailable environments:* HA bare-metal capacity.
   - *Sign-off:* Martin Tessun / 2026-05-13
 
 **Untestable Aspects**
@@ -321,11 +358,9 @@ The following conditions must be met before testing can begin:
 
 **Resource Constraints**
 
-- **Risk:** Manual ad-hoc testing for dual-stream live migration scenarios (OCPSTRAT-1150) requires
-  component team bandwidth through OCP 5.2, until Tier 2 automation (Option 3) is completed.
-  - **Mitigation:** Each participating SIG allocates time for ad-hoc runs in their test cycle.
-    Tier 2 automation will be added progressively. See Automation Testing in Section II.2 for the
-    full options analysis and decision rationale.
+- **Risk:** None identified.
+  - **Mitigation:** N/A — sig-virt dual-stream automation is done; other SIGs track any
+    pending automation in their child STPs (see Automation Testing).
   - *Missing resources or infrastructure:* N/A
   - *Sign-off:* Martin Tessun / 2026-05-13
 
@@ -345,18 +380,26 @@ The following conditions must be met before testing can begin:
 ### **III. Test Scenarios & Traceability**
 
 
-- **[CNV-81251](https://redhat.atlassian.net/browse/CNV-81251)** — As a VM operator, I want to live-migrate VMs between RHCOS9.8 and
-  RHCOS10.2 worker nodes within the same cluster so my workloads remain available during
+- **[CNV-81251](https://issues.redhat.com/browse/CNV-81251)** — As a VM operator, I want to live-migrate VMs between RHCOS9.x and
+  RHCOS10.x worker nodes within the same cluster so my workloads remain available during
   node maintenance.
-  - *Test Scenario:* [Tier 2] **Scenario 1** — VM created on an RHCOS9.8 worker node is live-migrated
-    to an RHCOS10.2 worker node without disruption; then migrate back to RHCOS9.8 without disruption.
+  - *Test Scenario:* [Tier 2] **Scenario 1** — A VM created on an RHCOS9.x worker node
+    is live-migrated to an RHCOS10.x worker node, then back to RHCOS9.x. For each migration:
+    the VM remains in Running phase throughout migration, a guest workload started before
+    migration continues running after migration without restart, and the VM is accessible
+    on the target node.
+  - *Guest OS:* RHEL, Windows
   - *Priority:* P1
 
-- **[CNV-81251](https://redhat.atlassian.net/browse/CNV-81251)** — As a VM operator, I want to live-migrate VMs between RHCOS9.8 and
-  RHCOS10.2 worker nodes within the same cluster so my workloads remain available during
+- **[CNV-81251](https://issues.redhat.com/browse/CNV-81251)** — As a VM operator, I want to live-migrate VMs between RHCOS9.x and
+  RHCOS10.x worker nodes within the same cluster so my workloads remain available during
   node maintenance.
-  - *Test Scenario:* [Tier 2] **Scenario 2** — VM created on an RHCOS10.2 worker node is live-migrated
-    to an RHCOS9.8 worker node without disruption; then migrate back to RHCOS10.2 without disruption.
+  - *Test Scenario:* [Tier 2] **Scenario 2** — A VM created on an RHCOS10.x worker node
+    is live-migrated to an RHCOS9.x worker node, then back to RHCOS10.x. For each migration:
+    the VM remains in Running phase throughout migration, a guest workload started before
+    migration continues running after migration without restart, and the VM is accessible
+    on the target node.
+  - *Guest OS:* RHEL, Windows
   - *Priority:* P1
 
 ---
@@ -366,12 +409,13 @@ The following conditions must be met before testing can begin:
 This Software Test Plan requires approval from the following stakeholders:
 
 - **Reviewers:**
-  - QE Members (sig-iuo): @OhadRevah
-  - QE Members (sig-network): @azhivovk
-  - QE Members (sig-storage): @jpeimer @kshvaika
-  - QE Members (sig-virt): @dshchedr @vsibirsk @SamAlber
-  - QE Members (sig-infra): @geetikakay @RoniKishner
+  - QE Members (sig-iuo): Ohad Revah (@OhadRevah)
+  - QE Members (sig-network): Asia Zhivov Khromov (@azhivovk)
+  - QE Members (sig-storage): Jenia Peimer (@jpeimer), Kate Shvaika (@kshvaika)
+  - QE Members (sig-virt): Denys Shchedrivyi (@dshchedr), Vasiliy Sibirskiy (@vsibirsk),
+    Samuel Alberstein (@SamAlber)
+  - QE Members (sig-infra): Geetika Kapoor (@geetikakay), Roni Kishner (@RoniKishner)
 - **Approvers:**
-  - QE Architect: [Ruth Netser](@rnetser)
-  - Principal Developer (sig-virt): Luboslav Pivarc @xpivarc
-  - Product Manager: [Martin Tessun] @mtessun
+  - QE Architect: Ruth Netser (@rnetser)
+  - Principal Developer (sig-virt): Luboslav Pivarc (@xpivarc)
+  - Product Manager: Martin Tessun (@mtessun)


### PR DESCRIPTION
### STP Metadata
update dual stream stp for cnv-5.0
**VEP issue**: https://redhat.atlassian.net/browse/CNV-84749
### What this PR does
<!-- Please summarize the STP update here -->

### Special notes for your reviewer


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated dual-stream RHCOS coverage to use RHCOS 9.x and 10.x terminology.
  * Added CNV 4.23 and 5.0 coverage, including RHCOS 10.x as the CNV 5.0 default.
  * Expanded migration scenarios with workload continuity, no-restart, running-phase, and target-accessibility checks.
  * Added RHCOS 9.x regression coverage and clarified HA test environment requirements.
  * Documented validated provisioning dependencies, automation coverage, and FIPS-enabled cloud testing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->